### PR TITLE
Add new OOPSLA1/OOPSLA2 publication strings

### DIFF
--- a/pubs.py
+++ b/pubs.py
@@ -45,7 +45,7 @@ CONFERENCES_NUMBER = {
     'sys_mob': {},
     'sys_mes': {},
     'sys_os': {},
-    'sys_pl': {'Proc. ACM Program. Lang.' : ['POPL', 'OOPSLA', 'ICFP']},
+    'sys_pl': {'Proc. ACM Program. Lang.' : ['POPL', 'OOPSLA', 'OOPSLA1', 'OOPSLA2', 'ICFP']},
     'sys_se': {}
 }
 


### PR DESCRIPTION
OOPSLA publications are now marked as OOPSLA1 and OOPSLA2, corresponding to the two deadlines of the conference.

For instance, notice how my paper "The Ultimate Conditional Syntax" appears on [my DBLP page](https://dblp.org/pid/181/5785.html):
```
The Ultimate Conditional Syntax. Proc. ACM Program. Lang. 8(OOPSLA2): 988-1017 (2024)
```

As a result, the PL ranking is currently broken. This seems to fix it.